### PR TITLE
reenable actuator/info, disabled by springboot 2.5

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,12 @@ logging:
     # To print db information at startup for postgres
     com.zaxxer.hikari.HikariConfig: DEBUG
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,info"
+
 spring:
   # to have webservices connect to localhost in IDEs
   profiles:


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
no /actuator/info


**What is the new behavior (if this is a feature change)?**
/actuator/info, eg
```json
{
  "git": {
    "branch": "main",
    "commit": {
      "id": "c25c6a0",
      "time": "2022-07-05T11:46:16Z"
    }
  },
  "build": {
    "artifact": "powsybl-network-store-server",
    "name": "Network store server",
    "time": "2022-07-21T08:57:45.718Z",
    "version": "1.0.0-SNAPSHOT",
    "group": "com.powsybl"
  }
}
```


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
Disabled in springboot 2.5, we want it back