### PR TITLE
Allow to specify only powsybl-ws.environment for ES/RABBIT/DB prefix configuration

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -127,22 +127,24 @@ customQuery:
 #dbName:
 
 powsybl-ws:
+  environment:
+
   # To set elasticsearch index names prefixes (default empty)
   # please use a separator '_' at prefix end for readiness
   elasticsearch:
     index:
-      prefix:
+      prefix: ${powsybl-ws.environment:}
 
   # To set rabbitmq bidings destination prefixes (default empty)
   # please use a separator '_' at prefix end for readiness
   rabbitmq:
     destination:
-      prefix:
+      prefix: ${powsybl-ws.environment:}
 
   # To set postgres database or schema prefixes (default empty)
   # please use a separator '_' at prefix end for readiness
   postgres:
     databaseOrSchema:
-      prefix:
+      prefix: ${powsybl-ws.environment:}
 
 dbPrefix: ${powsybl-ws.postgres.databaseOrSchema.prefix:}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
our deployments all have:
```
powsybl-ws:
  environment: FOO_
  # Postgres database prefix
  postgres:
    databaseOrSchema:
      prefix: ${powsybl-ws.environment:}
  # RabbitMQ binding destination prefixes
  rabbitmq:
    destination:
      prefix: ${powsybl-ws.environment:}
  # elasticsearch index prefixes
  elasticsearch:
    index:
      prefix: ${powsybl-ws.environment:}
```

**What is the new behavior (if this is a feature change)?**
our deployments can become:
```
powsybl-ws:
  environment: FOO_
```


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
