### PR TITLE
HOSTNAME property now has a default value in order to work when started in IDE

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 # to have the hostname in /actuator/info
 info:
-  hostname: ${HOSTNAME}
+  hostname: ${HOSTNAME:}
 
 server:
   # for springdoc swagger-ui behind a reverse proxy (X-FORWARDED-*)


### PR DESCRIPTION
Signed-off-by: LE SAULNIER Kevin <kevin.lesaulnier@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Starting a project depending on ws-commons from an IDE will not work since HOSTNAME is not defined here


**What is the new behavior (if this is a feature change)?**
Starting a project depending on ws-commons from an IDE will now work properly with HOSTNAME defined to empty