### PR TITLE
Add startup db logs, displayed even if liquibase fails

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,7 @@ logging:
   level:
     # To print db information at startup for postgres
     com.zaxxer.hikari.HikariConfig: DEBUG
+    org.springframework.jdbc.datasource.SimpleDriverDataSource: DEBUG
 
 management:
   endpoints:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The only db logs are from the hikaricp config, which is not displayed if liquibase fails


**What is the new behavior (if this is a feature change)?**
Simple log displayed before liquibase:
2023-09-29T19:29:36.275Z DEBUG 1 --- [           main] o.s.j.datasource.SimpleDriverDataSource  : Creating new JDBC Driver Connection to [jdbc:postgresql://postgres:5432/gridsuite_rec?currentSchema=XYZ]



**Does this PR introduce a breaking change or deprecate an API?**
NO


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
