### PR TITLE
Fail instead of warn when pagining in memory

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -85,6 +85,9 @@ spring:
         # Used when action: create is uncommented
         hbm2ddl:
           delimiter: ;
+        query:
+          # Explicitly fail the warning "HHH000104: firstResult/maxResults specified with collection fetch; applying in memory!"
+          fail_on_pagination_over_collection_fetch: true
       # Uncomment action to automatically generate the database sql schema file
       javax:
         persistence:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [ ] ~Docs have been added / updated (for bug fixes / features)~


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
For some requests, fetching all results then pagining in memory, with only a warning “HHH000104: firstResult/maxResults specified with collection fetch; applying in memory!” in logs.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Change the configuration of Hibernate to fix this situation and detect it sooner during devs.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
For some requests, fetching all results then pagining in memory, with only a warning HHH000104 in logs.


**What is the new behavior (if this is a feature change)?**
Fail instead of warning when fetching all results and pagining in memory.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
