### PR TITLE
Fix lombok annotations for Javadoc

### DIFF
--- a/src/main/java/com/powsybl/ws/commons/springboot/PowsyblWsCommonAutoConfiguration.java
+++ b/src/main/java/com/powsybl/ws/commons/springboot/PowsyblWsCommonAutoConfiguration.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.ws.commons.springboot;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/powsybl/ws/commons/springboot/PowsyblWsCommonAutoConfiguration.java
+++ b/src/main/java/com/powsybl/ws/commons/springboot/PowsyblWsCommonAutoConfiguration.java
@@ -3,7 +3,6 @@ package com.powsybl.ws.commons.springboot;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.startup.Tomcat;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -15,7 +14,7 @@ import org.springframework.context.annotation.Bean;
 @Slf4j
 @AutoConfiguration
 @EnableConfigurationProperties({ PowsyblWsCommonProperties.class })
-@AllArgsConstructor(onConstructor_ = {@Autowired})
+@AllArgsConstructor()
 public class PowsyblWsCommonAutoConfiguration {
     private final PowsyblWsCommonProperties properties;
 

--- a/src/main/java/com/powsybl/ws/commons/springboot/PowsyblWsCommonProperties.java
+++ b/src/main/java/com/powsybl/ws/commons/springboot/PowsyblWsCommonProperties.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.ws.commons.springboot;
 
 import lombok.Data;

--- a/src/main/java/com/powsybl/ws/commons/springboot/TomcatCustomization.java
+++ b/src/main/java/com/powsybl/ws/commons/springboot/TomcatCustomization.java
@@ -5,13 +5,12 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.Connector;
 import org.apache.tomcat.util.buf.EncodedSolidusHandling;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@AllArgsConstructor(onConstructor_ = {@Autowired})
+@AllArgsConstructor()
 public class TomcatCustomization implements TomcatConnectorCustomizer {
     private final TomcatPowsyblProperties properties;
 

--- a/src/main/java/com/powsybl/ws/commons/springboot/TomcatCustomization.java
+++ b/src/main/java/com/powsybl/ws/commons/springboot/TomcatCustomization.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.ws.commons.springboot;
 
 import com.powsybl.ws.commons.springboot.PowsyblWsCommonProperties.TomcatPowsyblProperties;

--- a/src/test/java/com/powsybl/ws/commons/SpringBootAutoConfigurationTest.java
+++ b/src/test/java/com/powsybl/ws/commons/SpringBootAutoConfigurationTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.ws.commons;
 
 import com.powsybl.ws.commons.springboot.PowsyblWsCommonAutoConfiguration;

--- a/src/test/java/com/powsybl/ws/commons/SpringBootAutoConfigurationTomcatTest.java
+++ b/src/test/java/com/powsybl/ws/commons/SpringBootAutoConfigurationTomcatTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.ws.commons;
 
 import com.powsybl.ws.commons.springboot.PowsyblWsCommonAutoConfiguration;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [ ] ~Docs have been added / updated (for bug fixes / features)~


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Remove the arguments throwing error with javadoc plugin.  
Also add missing license headers.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Compilation fail with `release` profile.


**What is the new behavior (if this is a feature change)?**
Javadoc generation pass.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] ~The *Breaking Change* or *Deprecated* label has been added~
- [ ] ~The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*~


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
The other solution would be to use delombok plugin , like describe here: https://stackoverflow.com/a/58698235