### PR TITLE
manage logs when a exception is caught in WorkerService

### DIFF
--- a/src/main/java/com/powsybl/ws/commons/computation/service/AbstractWorkerService.java
+++ b/src/main/java/com/powsybl/ws/commons/computation/service/AbstractWorkerService.java
@@ -116,9 +116,13 @@ public abstract class AbstractWorkerService<R, C extends AbstractComputationRunC
         return result != null;
     }
 
-    protected abstract void addLogsWhenFailed(C runContext, AtomicReference<ReportNode> rootReportNode);
+    protected void addLogsWhenFailed(C runContext, AtomicReference<ReportNode> rootReportNode) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
 
-    protected abstract boolean exceptionHasLogs(Exception e);
+    protected boolean exceptionHasLogs(Exception exception) {
+        return false;
+    }
 
     public Consumer<Message<String>> consumeRun() {
         return message -> {
@@ -147,6 +151,7 @@ public abstract class AbstractWorkerService<R, C extends AbstractComputationRunC
                 Thread.currentThread().interrupt();
             } catch (Exception e) {
                 if (exceptionHasLogs(e)) {
+                    LOGGER.error(NotificationService.getFailedMessage(getComputationType()), e);
                     addLogsWhenFailed(resultContext.getRunContext(), rootReporter);
                     publishFail(resultContext, e.getMessage());
                     sendResultMessage(resultContext, null);

--- a/src/main/java/com/powsybl/ws/commons/computation/service/AbstractWorkerService.java
+++ b/src/main/java/com/powsybl/ws/commons/computation/service/AbstractWorkerService.java
@@ -120,7 +120,7 @@ public abstract class AbstractWorkerService<R, C extends AbstractComputationRunC
         throw new UnsupportedOperationException("Not implemented");
     }
 
-    protected boolean exceptionHasLogs(Exception exception) {
+    protected boolean isFailureWithLogs(Exception exception) {
         return false;
     }
 
@@ -150,7 +150,7 @@ public abstract class AbstractWorkerService<R, C extends AbstractComputationRunC
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             } catch (Exception e) {
-                if (exceptionHasLogs(e)) {
+                if (isFailureWithLogs(e)) {
                     LOGGER.error(NotificationService.getFailedMessage(getComputationType()), e);
                     addLogsWhenFailed(resultContext.getRunContext(), rootReporter);
                     publishFail(resultContext, e.getMessage());

--- a/src/test/java/com/powsybl/ws/commons/computation/ComputationTest.java
+++ b/src/test/java/com/powsybl/ws/commons/computation/ComputationTest.java
@@ -1,7 +1,6 @@
 package com.powsybl.ws.commons.computation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.powsybl.commons.report.ReportNode;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VariantManager;
 import com.powsybl.network.store.client.NetworkStoreService;
@@ -40,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static com.powsybl.ws.commons.computation.service.NotificationService.HEADER_RECEIVER;
 import static com.powsybl.ws.commons.computation.service.NotificationService.HEADER_RESULT_UUID;
@@ -166,16 +164,6 @@ class ComputationTest implements WithAssertions {
         @Override
         protected AbstractResultContext<MockComputationRunContext> fromMessage(Message<String> message) {
             return resultContext;
-        }
-
-        @Override
-        protected void addLogsWhenFailed(MockComputationRunContext runContext, AtomicReference<ReportNode> rootReportNode) {
-
-        }
-
-        @Override
-        protected boolean isFailureWithLogs(Exception e) {
-            return true;
         }
 
         @Override

--- a/src/test/java/com/powsybl/ws/commons/computation/ComputationTest.java
+++ b/src/test/java/com/powsybl/ws/commons/computation/ComputationTest.java
@@ -174,7 +174,7 @@ class ComputationTest implements WithAssertions {
         }
 
         @Override
-        protected boolean exceptionHasLogs(Exception e) {
+        protected boolean isFailureWithLogs(Exception e) {
             return true;
         }
 

--- a/src/test/java/com/powsybl/ws/commons/computation/ComputationTest.java
+++ b/src/test/java/com/powsybl/ws/commons/computation/ComputationTest.java
@@ -1,6 +1,7 @@
 package com.powsybl.ws.commons.computation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.powsybl.commons.report.ReportNode;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VariantManager;
 import com.powsybl.network.store.client.NetworkStoreService;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.powsybl.ws.commons.computation.service.NotificationService.HEADER_RECEIVER;
 import static com.powsybl.ws.commons.computation.service.NotificationService.HEADER_RESULT_UUID;
@@ -164,6 +166,16 @@ class ComputationTest implements WithAssertions {
         @Override
         protected AbstractResultContext<MockComputationRunContext> fromMessage(Message<String> message) {
             return resultContext;
+        }
+
+        @Override
+        protected void addLogsWhenFailed(MockComputationRunContext runContext, AtomicReference<ReportNode> rootReportNode) {
+
+        }
+
+        @Override
+        protected boolean exceptionHasLogs(Exception e) {
+            return true;
         }
 
         @Override


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
feature

**What is the new behavior (if this is a feature change)?**
it allow to manage logs when a exception is raised 


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
the run method has now a new argument : 
```java
AtomicReference<ReportNode> rootReportNode
```
two new methods have been added to the interface AbstractWorkerService :
```java 
protected abstract void addLogsWhenFailed(C runContext, AtomicReference<ReportNode> rootReportNode);

protected abstract boolean exceptionHasLogs(Exception e);
```


