### PR TITLE
Fix: Replace max-http-header-size with max-http-request-header-size

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,7 +9,7 @@ server:
   error:
     include-message: always
   # increase max url length
-  max-http-header-size: 64000
+  max-http-request-header-size: 64000
   # enable monitoring of tomcat threads and thread pool
   tomcat:
     mbeanregistry:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix: max-http-header-size was replaced by max-http-request-header-size in springboot 3.3
