### PR TITLE
feat: let consumeRun throw to let message broker handle failures

### DIFF
--- a/src/main/java/com/powsybl/ws/commons/computation/ComputationException.java
+++ b/src/main/java/com/powsybl/ws/commons/computation/ComputationException.java
@@ -10,6 +10,10 @@ package com.powsybl.ws.commons.computation;
  * @author Joris Mancini <joris.mancini_externe at rte-france.com>
  */
 public class ComputationException extends RuntimeException {
+    public ComputationException(String message) {
+        super(message);
+    }
+
     public ComputationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/powsybl/ws/commons/computation/ComputationException.java
+++ b/src/main/java/com/powsybl/ws/commons/computation/ComputationException.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.ws.commons.computation;
+
+/**
+ * @author Joris Mancini <joris.mancini_externe at rte-france.com>
+ */
+public class ComputationException extends RuntimeException {
+    public ComputationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/powsybl/ws/commons/computation/service/AbstractWorkerService.java
+++ b/src/main/java/com/powsybl/ws/commons/computation/service/AbstractWorkerService.java
@@ -142,7 +142,7 @@ public abstract class AbstractWorkerService<R, C extends AbstractComputationRunC
                     LOGGER.info("{} complete (resultUuid='{}')", getComputationType(), resultContext.getResultUuid());
                 }
             } catch (CancellationException e) {
-                LOGGER.info("Computation was interrupted");
+                // Do nothing
             } catch (Exception e) {
                 resultService.delete(resultContext.getResultUuid());
                 this.handleNonCancellationException(resultContext, e, rootReporter);

--- a/src/main/java/com/powsybl/ws/commons/computation/service/AbstractWorkerService.java
+++ b/src/main/java/com/powsybl/ws/commons/computation/service/AbstractWorkerService.java
@@ -13,6 +13,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VariantManagerConstants;
 import com.powsybl.network.store.client.NetworkStoreService;
 import com.powsybl.network.store.client.PreloadingStrategy;
+import com.powsybl.ws.commons.computation.ComputationException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,10 +24,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -147,10 +145,9 @@ public abstract class AbstractWorkerService<R, C extends AbstractComputationRunC
                 Thread.currentThread().interrupt();
             } catch (Exception e) {
                 if (!(e instanceof CancellationException)) {
-                    LOGGER.error(NotificationService.getFailedMessage(getComputationType()), e);
-                    publishFail(resultContext, e.getMessage());
                     resultService.delete(resultContext.getResultUuid());
                     this.handleNonCancellationException(resultContext, e, rootReporter);
+                    throw new ComputationException(NotificationService.getFailedMessage(getComputationType()), e);
                 }
             } finally {
                 clean(resultContext);
@@ -190,11 +187,6 @@ public abstract class AbstractWorkerService<R, C extends AbstractComputationRunC
     protected void sendResultMessage(AbstractResultContext<C> resultContext, R ignoredResult) {
         notificationService.sendResultMessage(resultContext.getResultUuid(), resultContext.getRunContext().getReceiver(),
                 resultContext.getRunContext().getUserId(), null);
-    }
-
-    protected void publishFail(AbstractResultContext<C> resultContext, String message) {
-        notificationService.publishFail(resultContext.getResultUuid(), resultContext.getRunContext().getReceiver(),
-                message, resultContext.getRunContext().getUserId(), getComputationType(), null);
     }
 
     /**

--- a/src/main/java/com/powsybl/ws/commons/computation/service/NotificationService.java
+++ b/src/main/java/com/powsybl/ws/commons/computation/service/NotificationService.java
@@ -21,8 +21,6 @@ import org.springframework.stereotype.Service;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.powsybl.ws.commons.computation.utils.MessageUtils.shortenMessage;
-
 /**
  * @author Etienne Homer <etienne.homer at rte-france.com
  */
@@ -92,21 +90,6 @@ public class NotificationService {
                 .build();
         STOP_MESSAGE_LOGGER.debug(SENDING_MESSAGE, message);
         publisher.send(publishPrefix + "Stopped-out-0", message);
-    }
-
-    @PostCompletion
-    public void publishFail(UUID resultUuid, String receiver, String causeMessage, String userId, String computationLabel, Map<String, Object> additionalHeaders) {
-        MessageBuilder<String> builder = MessageBuilder
-                .withPayload("")
-                .setHeader(HEADER_RESULT_UUID, resultUuid.toString())
-                .setHeader(HEADER_RECEIVER, receiver)
-                .setHeader(HEADER_MESSAGE, shortenMessage(
-                        getFailedMessage(computationLabel) + " : " + causeMessage))
-                .setHeader(HEADER_USER_ID, userId)
-                .copyHeaders(additionalHeaders);
-        Message<String> message = builder.build();
-        FAILED_MESSAGE_LOGGER.debug(SENDING_MESSAGE, message);
-        publisher.send(publishPrefix + "Failed-out-0", message);
     }
 
     @PostCompletion

--- a/src/test/java/com/powsybl/ws/commons/computation/ComputationExceptionTest.java
+++ b/src/test/java/com/powsybl/ws/commons/computation/ComputationExceptionTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.ws.commons.computation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Joris Mancini <joris.mancini_externe at rte-france.com>
+ */
+class ComputationExceptionTest {
+
+    @Test
+    void testMessageConstructor() {
+        var e = new ComputationException("test");
+        assertEquals("test", e.getMessage());
+    }
+
+    @Test
+    void testMessageAndThrowableConstructor() {
+        var cause = new RuntimeException("test");
+        var e = new ComputationException("test", cause);
+        assertEquals("test", e.getMessage());
+        assertEquals(cause, e.getCause());
+    }
+}

--- a/src/test/java/com/powsybl/ws/commons/computation/ComputationTest.java
+++ b/src/test/java/com/powsybl/ws/commons/computation/ComputationTest.java
@@ -44,6 +44,7 @@ import static com.powsybl.ws.commons.computation.service.NotificationService.HEA
 import static com.powsybl.ws.commons.computation.service.NotificationService.HEADER_RESULT_UUID;
 import static com.powsybl.ws.commons.computation.service.NotificationService.HEADER_USER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -257,10 +258,7 @@ class ComputationTest implements WithAssertions {
         runContext.setComputationResWanted(ComputationResultWanted.FAIL);
 
         // execution / cleaning
-        workerService.consumeRun().accept(message);
-
-        // test the course
-        verify(notificationService.getPublisher(), times(1)).send(eq("publishFailed-out-0"), isA(Message.class));
+        assertThrows(ComputationException.class, () -> workerService.consumeRun().accept(message));
     }
 
     @Test

--- a/src/test/java/com/powsybl/ws/commons/computation/ComputationTest.java
+++ b/src/test/java/com/powsybl/ws/commons/computation/ComputationTest.java
@@ -285,7 +285,7 @@ class ComputationTest implements WithAssertions {
     }
 
     @Test
-    void testComputationCancelledIfNoMatchingFuture() {
+    void testComputationNotCancelledIfNoMatchingFuture() {
         MockComputationStatus baseStatus = MockComputationStatus.NOT_DONE;
         computationService.setStatus(List.of(RESULT_UUID), baseStatus);
         assertEquals(baseStatus, computationService.getStatus(RESULT_UUID));
@@ -294,11 +294,11 @@ class ComputationTest implements WithAssertions {
         computationService.stop(RESULT_UUID, receiver);
         verify(notificationService.getPublisher(), times(1)).send(eq("publishCancel-out-0"), isA(Message.class));
 
-        // Test data is cleaned and message is sent in stopped
+        // Test data is not cleaned and message is sent in cancelfailed
         workerService.addFuture(UUID.randomUUID(), Mockito.mock(CompletableFuture.class));
         workerService.consumeCancel().accept(message);
-        assertNull(resultService.findStatus(RESULT_UUID));
-        verify(notificationService.getPublisher(), times(1)).send(eq("publishStopped-out-0"), isA(Message.class));
+        assertNotNull(resultService.findStatus(RESULT_UUID));
+        verify(notificationService.getPublisher(), times(1)).send(eq("publishCancelFailed-out-0"), isA(Message.class));
     }
 
     @Test
@@ -311,7 +311,7 @@ class ComputationTest implements WithAssertions {
         computationService.stop(RESULT_UUID, receiver);
         verify(notificationService.getPublisher(), times(1)).send(eq("publishCancel-out-0"), isA(Message.class));
 
-        // Test data is not cleaned and message is sent in stopped
+        // Test data is not cleaned and message is sent in cancelfailed
         CompletableFuture<Object> futureThatCouldNotBeCancelled = Mockito.mock(CompletableFuture.class);
         when(futureThatCouldNotBeCancelled.cancel(true)).thenReturn(false);
         workerService.addFuture(RESULT_UUID, futureThatCouldNotBeCancelled);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
Change behavior of computation consumer to let it throw so that message broker can handle failures


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
