### PR TITLE
Set maximum number of Tomcat threads to 20

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,8 +10,10 @@ server:
     include-message: always
   # increase max url length
   max-http-request-header-size: 64000
-  # enable monitoring of tomcat threads and thread pool
   tomcat:
+    threads:
+      max: 20
+    # enable monitoring of tomcat threads and thread pool
     mbeanregistry:
       enabled: true
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Change the max number of Tomcat threads to 20. 
Given that the Hikari pool for DB connections is 10, we take an extra margin of 10 threads for HTTP requests without DB access (actuator endpoint polling, fetch admins in user-admin-server for example).
This should avoid some OOMKilled error in our microservices because we did not account for 200 threads in the memory sizing of our microservices (each thread should be around 1MB with Spring Boot and our functions (max: Xss = 4MB) so this adds 200MB to memory if all threads are used). 

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Max number of threads is 200 (default).

**What is the new behavior (if this is a feature change)?**
Max number of Tomcat threads is 20.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
