### PR TITLE
Revert "Set maximum number of Tomcat threads to 20"

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,10 +10,8 @@ server:
     include-message: always
   # increase max url length
   max-http-request-header-size: 64000
+  # enable monitoring of tomcat threads and thread pool
   tomcat:
-    threads:
-      max: 20
-    # enable monitoring of tomcat threads and thread pool
     mbeanregistry:
       enabled: true
 


### PR DESCRIPTION
Reverts powsybl/powsybl-ws-commons#106
We can't use this configuration in all our microservices. The main issue is that if all tomcat threads are busy, the actuator probes don't return and the pod is killed. This is also not the best fit for microservices acting like gateway (study-server, explore-server), where small request will be blocked and not even sent to the downstream server if only one slow servers hogs all the http threads. This will happen for downstream servers that have in memory queues to protect themselves from crashing from out of memory. Also a similiar problem happens for severs with fast requests and slow requests (again for example these in memory queues).

These issues can still happen with the default 200 threads but it's less likely. Instead, we can adjust our memory limits or use virtual threads.